### PR TITLE
Fix issue with extraction of negative integers

### DIFF
--- a/src/yxdb/_extractors.py
+++ b/src/yxdb/_extractors.py
@@ -23,7 +23,7 @@ def new_int16_extractor(start: int):
     def e(buffer: memoryview):
         if buffer[start+2] == 1:
             return None
-        return int.from_bytes(buffer[start:start+2], 'little')
+        return int.from_bytes(buffer[start:start+2], byteorder='little', signed=True)
     return e
 
 
@@ -31,7 +31,7 @@ def new_int32_extractor(start: int):
     def e(buffer: memoryview):
         if buffer[start+4] == 1:
             return None
-        return int.from_bytes(buffer[start:start+4], 'little')
+        return int.from_bytes(buffer[start:start+4], byteorder='little', signed=True)
     return e
 
 
@@ -39,7 +39,7 @@ def new_int64_extractor(start: int):
     def e(buffer: memoryview):
         if buffer[start+8] == 1:
             return None
-        return int.from_bytes(buffer[start:start+8], 'little')
+        return int.from_bytes(buffer[start:start+8], byteorder='little', signed=True)
     return e
 
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -14,6 +14,16 @@ class TestExtractors(unittest.TestCase):
         result = extract(memview([0, 0, 10, 0, 1, 0]))
         self.assertEqual(None, result)
 
+    def test_extract_negative_one_int16(self):
+        extract = new_int16_extractor(4)
+        result = extract(memview([0, 0, 0, 0, 255, 255, 0]))
+        self.assertEqual(-1, result)
+
+    def test_extract_negative_max_int16(self):
+        extract = new_int16_extractor(4)
+        result = extract(memview([0, 0, 0, 0, 0, 128, 0]))
+        self.assertEqual(-2**15, result)
+
     def test_extract_int32(self):
         extract = new_int32_extractor(3)
         result = extract(memview([0, 0, 0, 10, 0, 0, 0, 0]))
@@ -24,6 +34,16 @@ class TestExtractors(unittest.TestCase):
         result = extract(memview([0, 0, 0, 10, 0, 0, 0, 1]))
         self.assertEqual(None, result)
 
+    def test_extract_negative_one_int32(self):
+        extract = new_int32_extractor(4)
+        result = extract(memview([0, 0, 0, 0, 255, 255, 255, 255, 0]))
+        self.assertEqual(-1, result)
+
+    def test_extract_negative_max_int32(self):
+        extract = new_int32_extractor(4)
+        result = extract(memview([0, 0, 0, 0, 0, 0, 0, 128, 0]))
+        self.assertEqual(-2**31, result)        
+
     def test_extract_int64(self):
         extract = new_int64_extractor(4)
         result = extract(memview([0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0]))
@@ -33,6 +53,16 @@ class TestExtractors(unittest.TestCase):
         extract = new_int64_extractor(4)
         result = extract(memview([0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1]))
         self.assertEqual(None, result)
+
+    def test_extract_negative_one_int64(self):
+        extract = new_int64_extractor(4)
+        result = extract(memview([0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0]))
+        self.assertEqual(-1, result)
+
+    def test_extract_negative_max_int64(self):
+        extract = new_int64_extractor(4)
+        result = extract(memview([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0]))
+        self.assertEqual(-2**63, result)
 
     def test_extract_bool(self):
         extract = new_bool_extractor(4)


### PR DESCRIPTION
Hi, this fixes [issue 3](https://github.com/tlarsendataguy-yxdb/yxdb-py/issues/3), by adding `signed=True` to `int.from_bytes` in the integer extractors, and provides some test cases to cover negative integers.